### PR TITLE
Update AMP dashboard towards ingestion

### DIFF
--- a/artifacts/grafana-dashboards/amp/amp-dashboard.json
+++ b/artifacts/grafana-dashboards/amp/amp-dashboard.json
@@ -1,9 +1,67 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_AWS-OBSERVABILITY-ACCELERATOR",
+      "label": "aws-observability-accelerator",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "panel",
+      "id": "bargauge",
+      "name": "Bar gauge",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "cloudwatch",
+      "name": "CloudWatch",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "gauge",
+      "name": "Gauge",
+      "version": ""
+    },
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "9.4.7"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {
         "builtIn": 1,
-        "datasource": "-- Grafana --",
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -22,26 +80,458 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 51,
-  "iteration": 1666292684202,
+  "id": null,
   "links": [],
   "liveNow": false,
   "panels": [
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_AWS-OBSERVABILITY-ACCELERATOR}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
       "gridPos": {
-        "h": 7,
-        "w": 5,
+        "h": 15,
+        "w": 11,
         "x": 0,
         "y": 0
       },
-      "id": 16,
+      "id": 29,
       "options": {
-        "content": "# Ingestion Usage Metrics\n\nMetrics relating to ingestion usage of the AMP service",
-        "mode": "markdown"
+        "footer": {
+          "countRows": false,
+          "enablePagination": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "frameIndex": 7,
+        "showHeader": false
       },
-      "pluginVersion": "8.4.7",
-      "title": "Usage",
-      "type": "text"
+      "pluginVersion": "9.4.7",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_AWS-OBSERVABILITY-ACCELERATOR}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "topk(10, count by (__name__)({__name__=~\"^[a-b].+\"}))",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_AWS-OBSERVABILITY-ACCELERATOR}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "topk(10, count by (__name__)({__name__=~\"^[c-d].+\"}))",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_AWS-OBSERVABILITY-ACCELERATOR}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "topk(10, count by (__name__)({__name__=~\"^[e-f].+\"}))",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_AWS-OBSERVABILITY-ACCELERATOR}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "topk(10, count by (__name__)({__name__=~\"^[g-i].+\"}))",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_AWS-OBSERVABILITY-ACCELERATOR}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "topk(10, count by (__name__)({__name__=~\"^[j-l].+\"}))",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_AWS-OBSERVABILITY-ACCELERATOR}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "topk(10, count by (__name__)({__name__=~\"^[m-o].+\"}))",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "F"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_AWS-OBSERVABILITY-ACCELERATOR}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "topk(10, count by (__name__)({__name__=~\"^[p-r].+\"}))",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "G"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_AWS-OBSERVABILITY-ACCELERATOR}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "topk(10, count by (__name__)({__name__=~\"^[s-z].+\"}))",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "H"
+        }
+      ],
+      "title": "Top 20 high cardinality metrics",
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "mode": "reduceRow",
+            "reduce": {
+              "include": [],
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Value #A": true,
+              "Value #B": true,
+              "Value #C": true,
+              "Value #D": true,
+              "Value #E": true,
+              "Value #F": true,
+              "Value #G": true,
+              "Value #H": true
+            },
+            "indexByName": {},
+            "renameByName": {}
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": true,
+                "field": "Total"
+              }
+            ]
+          }
+        },
+        {
+          "id": "limit",
+          "options": {
+            "limitField": 20
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_AWS-OBSERVABILITY-ACCELERATOR}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 13,
+        "x": 11,
+        "y": 0
+      },
+      "id": 26,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_AWS-OBSERVABILITY-ACCELERATOR}"
+          },
+          "editorMode": "code",
+          "expr": "max by (job) (scrape_series_added{job=~\"^$job$\"})",
+          "legendFormat": "{{job}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Scrape series per job",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_AWS-OBSERVABILITY-ACCELERATOR}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 11,
+        "y": 7
+      },
+      "id": 25,
+      "options": {
+        "displayMode": "basic",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "9.4.7",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_AWS-OBSERVABILITY-ACCELERATOR}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (job) (up) ",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Jobs",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_AWS-OBSERVABILITY-ACCELERATOR}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-GrYlRd"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 7,
+        "x": 17,
+        "y": 7
+      },
+      "id": 28,
+      "options": {
+        "displayMode": "basic",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "9.4.7",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_AWS-OBSERVABILITY-ACCELERATOR}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (alertname) (ALERTS{})",
+          "instant": true,
+          "legendFormat": "{{alertname}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "alerts firing",
+      "type": "bargauge"
     },
     {
       "datasource": {
@@ -54,6 +544,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -101,15 +593,16 @@
       "gridPos": {
         "h": 7,
         "w": 9,
-        "x": 5,
-        "y": 0
+        "x": 0,
+        "y": 15
       },
       "id": 6,
       "options": {
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -126,6 +619,7 @@
           "dimensions": {},
           "expression": "SELECT SUM(ResourceCount) FROM SCHEMA(\"AWS/Usage\", Class,Resource,ResourceId,Service,Type) WHERE Type = 'Resource' AND ResourceId = '$WorkspaceID' AND Resource = 'ActiveSeries' AND Service = 'Prometheus' AND Class = 'None'",
           "id": "",
+          "label": "",
           "matchExact": true,
           "metricEditorMode": 1,
           "metricName": "",
@@ -153,6 +647,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -199,16 +695,17 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 9,
-        "x": 14,
-        "y": 0
+        "w": 15,
+        "x": 9,
+        "y": 15
       },
       "id": 2,
       "options": {
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -242,58 +739,96 @@
       "type": "timeseries"
     },
     {
-      "gridPos": {
-        "h": 8,
-        "w": 5,
-        "x": 0,
-        "y": 7
-      },
-      "id": 22,
-      "options": {
-        "content": "# Billing\n\nContains information relating to the cost of AMP\n\n",
-        "mode": "markdown"
-      },
-      "pluginVersion": "8.4.7",
-      "title": "Billing",
-      "type": "text"
-    },
-    {
       "datasource": {
-        "type": "cloudwatch",
-        "uid": "$datasource"
+        "type": "prometheus",
+        "uid": "${DS_AWS-OBSERVABILITY-ACCELERATOR}"
       },
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 9,
+        "x": 0,
+        "y": 22
+      },
+      "id": 30,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": false
+      },
+      "pluginVersion": "9.4.7",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_AWS-OBSERVABILITY-ACCELERATOR}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(scrape_series_added)",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "scrape_series_added",
+          "range": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_AWS-OBSERVABILITY-ACCELERATOR}"
+          },
+          "editorMode": "code",
+          "expr": "sum(scrape_samples_scraped)",
+          "hide": false,
+          "legendFormat": "scrape_samples_scraped",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Scrape series per job",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_AWS-OBSERVABILITY-ACCELERATOR}"
+      },
+      "description": "Helps finding out variance in samples collected between scrape intervals",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
           },
           "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
             },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
+            "inspect": false
           },
           "mappings": [],
           "thresholds": {
@@ -313,439 +848,89 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 18,
-        "x": 5,
-        "y": 7
-      },
-      "id": 24,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "alias": "",
-          "datasource": {
-            "type": "cloudwatch",
-            "uid": "$datasource"
-          },
-          "dimensions": {},
-          "expression": "SELECT SUM(EstimatedCharges) FROM SCHEMA(\"AWS/Billing\", Currency,ServiceName) WHERE ServiceName = 'AmazonPrometheus'",
-          "id": "",
-          "matchExact": true,
-          "metricEditorMode": 1,
-          "metricName": "",
-          "metricQueryType": 0,
-          "namespace": "",
-          "period": "",
-          "queryMode": "Metrics",
-          "refId": "A",
-          "region": "default",
-          "sqlExpression": "",
-          "statistic": "Average"
-        }
-      ],
-      "title": "Sum of Estimated AMP Charges (total)",
-      "type": "timeseries"
-    },
-    {
-      "gridPos": {
-        "h": 9,
-        "w": 5,
-        "x": 0,
-        "y": 15
-      },
-      "id": 14,
-      "options": {
-        "content": "# Alert Usage Metrics\n\nMetrics associated with Alertmanager Alert Usage",
-        "mode": "markdown"
-      },
-      "pluginVersion": "8.4.7",
-      "title": "Alerts",
-      "type": "text"
-    },
-    {
-      "datasource": {
-        "type": "cloudwatch",
-        "uid": "$datasource"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 4,
-        "x": 5,
-        "y": 15
-      },
-      "id": 4,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "8.4.7",
-      "targets": [
-        {
-          "alias": "",
-          "datasource": {
-            "type": "cloudwatch",
-            "uid": "$datasource"
-          },
-          "dimensions": {},
-          "expression": "SELECT AVG(ResourceCount) FROM SCHEMA(\"AWS/Usage\", Class,Resource,ResourceId,Service,Type) WHERE Type = 'Resource' AND ResourceId = '$WorkspaceID' AND Resource = 'ActiveAlerts' AND Service = 'Prometheus' AND Class = 'None'",
-          "id": "",
-          "matchExact": true,
-          "metricEditorMode": 1,
-          "metricName": "",
-          "metricQueryType": 0,
-          "namespace": "",
-          "period": "",
-          "queryMode": "Metrics",
-          "refId": "A",
-          "region": "default",
-          "sqlExpression": "",
-          "statistic": "Average"
-        }
-      ],
-      "title": "Active Alerts",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "cloudwatch",
-        "uid": "$datasource"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 5,
+        "h": 7,
+        "w": 15,
         "x": 9,
-        "y": 15
+        "y": 22
       },
-      "id": 12,
+      "id": 27,
       "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+        "footer": {
+          "countRows": false,
           "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "8.4.7",
-      "targets": [
-        {
-          "alias": "",
-          "datasource": {
-            "type": "cloudwatch",
-            "uid": "$datasource"
-          },
-          "dimensions": {},
-          "expression": "SELECT AVG(AlertManagerNotificationsFailed) FROM SCHEMA(\"AWS/Prometheus\", Workspace) WHERE Workspace = '$WorkspaceID'",
-          "id": "",
-          "matchExact": true,
-          "metricEditorMode": 1,
-          "metricName": "",
-          "metricQueryType": 0,
-          "namespace": "",
-          "period": "",
-          "queryMode": "Metrics",
-          "refId": "A",
-          "region": "default",
-          "sqlExpression": "",
-          "statistic": "Average"
-        }
-      ],
-      "title": "Alert Manager Notifications Failed",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "cloudwatch",
-        "uid": "$datasource"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 4,
-        "x": 14,
-        "y": 15
-      },
-      "id": 10,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
+          "reducer": [
+            "sum"
           ],
-          "fields": "",
-          "values": false
+          "show": false
         },
-        "textMode": "auto"
+        "frameIndex": 3,
+        "showHeader": true
       },
-      "pluginVersion": "8.4.7",
-      "targets": [
-        {
-          "alias": "",
-          "datasource": {
-            "type": "cloudwatch",
-            "uid": "$datasource"
-          },
-          "dimensions": {},
-          "expression": "SELECT AVG(AlertManagerAlertsReceived) FROM SCHEMA(\"AWS/Prometheus\", Workspace) WHERE Workspace = '$WorkspaceID'",
-          "id": "",
-          "matchExact": true,
-          "metricEditorMode": 1,
-          "metricName": "",
-          "metricQueryType": 0,
-          "namespace": "",
-          "period": "",
-          "queryMode": "Metrics",
-          "refId": "A",
-          "region": "default",
-          "sqlExpression": "",
-          "statistic": "Average"
-        }
-      ],
-      "title": "Alert Manager Alerts Received",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "cloudwatch",
-        "uid": "$datasource"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 5,
-        "x": 18,
-        "y": 15
-      },
-      "id": 8,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "8.4.7",
-      "targets": [
-        {
-          "alias": "",
-          "datasource": {
-            "type": "cloudwatch",
-            "uid": "$datasource"
-          },
-          "dimensions": {},
-          "expression": "SELECT AVG(ResourceCount) FROM SCHEMA(\"AWS/Usage\", Class,Resource,ResourceId,Service,Type) WHERE Type = 'Resource' AND ResourceId = '$WorkspaceID' AND Resource = 'SizeOfAlerts' AND Service = 'Prometheus' AND Class = 'None'",
-          "id": "",
-          "matchExact": true,
-          "metricEditorMode": 1,
-          "metricName": "",
-          "metricQueryType": 0,
-          "namespace": "",
-          "period": "",
-          "queryMode": "Metrics",
-          "refId": "A",
-          "region": "default",
-          "sqlExpression": "",
-          "statistic": "Average"
-        }
-      ],
-      "title": "Size of Alerts",
-      "type": "stat"
-    },
-    {
-      "gridPos": {
-        "h": 7,
-        "w": 5,
-        "x": 0,
-        "y": 24
-      },
-      "id": 20,
-      "options": {
-        "content": "# AMP Vended Logs\n\nLast 25 log events from AMP Vended Logs for alert and rule evaluation",
-        "mode": "markdown"
-      },
-      "pluginVersion": "8.4.7",
-      "title": "AMP Logs",
-      "type": "text"
-    },
-    {
-      "datasource": {
-        "type": "cloudwatch",
-        "uid": "$datasource"
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 18,
-        "x": 5,
-        "y": 24
-      },
-      "id": 18,
-      "options": {
-        "dedupStrategy": "none",
-        "enableLogDetails": true,
-        "prettifyLogMessage": false,
-        "showCommonLabels": false,
-        "showLabels": false,
-        "showTime": false,
-        "sortOrder": "Descending",
-        "wrapLogMessage": false
-      },
+      "pluginVersion": "9.4.7",
       "targets": [
         {
           "datasource": {
-            "type": "cloudwatch",
-            "uid": "$datasource"
+            "type": "prometheus",
+            "uid": "${DS_AWS-OBSERVABILITY-ACCELERATOR}"
           },
-          "expression": "fields @timestamp, @message\n| sort @timestamp desc\n| limit 25",
-          "id": "",
-          "logGroupNames": [
-            "/aws/vendedlogs/amp"
-          ],
-          "namespace": "",
-          "queryMode": "Logs",
-          "refId": "A",
-          "region": "default",
-          "statsGroups": []
+          "editorMode": "code",
+          "expr": "topk(5, max_over_time(scrape_series_added[6m]))",
+          "legendFormat": "{{job}}",
+          "range": true,
+          "refId": "A"
         }
       ],
-      "timeFrom": "6h",
-      "timeShift": "6h",
-      "title": "AMP Vended Logs",
-      "type": "logs"
+      "title": "metrics variance over time per job",
+      "type": "table"
     }
   ],
   "refresh": "",
-  "schemaVersion": 35,
+  "revision": 1,
+  "schemaVersion": 38,
   "style": "dark",
   "tags": [],
   "templating": {
     "list": [
       {
         "current": {
-          "selected": true,
-          "text": [
-            "ws-e8b003eb-0528-4208-b31c-edf4598d5f66"
-          ],
-          "value": [
-            "ws-e8b003eb-0528-4208-b31c-edf4598d5f66"
-          ]
+          "selected": false,
+          "text": "aws-observability-accelerator",
+          "value": "aws-observability-accelerator"
         },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus data source",
+        "multi": false,
+        "name": "prometheus_datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "aws-observability-accelerator-cloudwatch",
+          "value": "aws-observability-accelerator-cloudwatch"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "CloudWatch data source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "cloudwatch",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {},
         "datasource": {
           "type": "cloudwatch",
           "uid": "$datasource"
@@ -753,10 +938,23 @@
         "definition": "dimension_values(default,AWS/Prometheus,RuleEvaluations,Workspace)",
         "hide": 0,
         "includeAll": false,
-        "multi": true,
+        "multi": false,
         "name": "WorkspaceID",
         "options": [],
-        "query": "dimension_values(default,AWS/Prometheus,RuleEvaluations,Workspace)",
+        "query": {
+          "attributeName": "",
+          "dimensionFilters": {},
+          "dimensionKey": "Workspace",
+          "ec2Filters": {},
+          "instanceID": "",
+          "metricName": "RuleEvaluations",
+          "namespace": "AWS/Prometheus",
+          "queryType": "dimensionValues",
+          "refId": "CloudWatchVariableQueryEditor-VariableQuery",
+          "region": "$prometheus_datasource",
+          "resourceType": "",
+          "tags": {}
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -764,32 +962,39 @@
         "type": "query"
       },
       {
-        "current": {
-          "selected": false,
-          "text": "Amazon CloudWatch us-west-2",
-          "value": "Amazon CloudWatch us-west-2"
+        "allValue": ".*",
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_AWS-OBSERVABILITY-ACCELERATOR}"
         },
+        "definition": "label_values(up, job)",
         "hide": 0,
-        "includeAll": false,
-        "multi": false,
-        "name": "datasource",
+        "includeAll": true,
+        "label": "Prometheus job",
+        "multi": true,
+        "name": "job",
         "options": [],
-        "query": "cloudwatch",
+        "query": {
+          "query": "label_values(up, job)",
+          "refId": "StandardVariableQuery"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
-        "type": "datasource"
+        "sort": 0,
+        "type": "query"
       }
     ]
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-3h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
-  "title": "AWS Observability Accelerator - AMP Dashboard",
-  "uid": "",
-  "version": 1,
+  "title": "AWS Observability Accelerator - AMP Ingestion Dashboard",
+  "uid": "qbYzyPXVz",
+  "version": 34,
   "weekStart": ""
 }

--- a/artifacts/grafana-dashboards/amp/amp-dashboard.json
+++ b/artifacts/grafana-dashboards/amp/amp-dashboard.json
@@ -91,13 +91,8 @@
       },
       "fieldConfig": {
         "defaults": {
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "filterable": false,
-            "inspect": false
+          "color": {
+            "mode": "continuous-GrYlRd"
           },
           "mappings": [],
           "thresholds": {
@@ -117,24 +112,25 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 15,
+        "h": 18,
         "w": 11,
         "x": 0,
         "y": 0
       },
-      "id": 29,
+      "id": 32,
       "options": {
-        "footer": {
-          "countRows": false,
-          "enablePagination": false,
-          "fields": "",
-          "reducer": [
-            "sum"
+        "displayMode": "basic",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
           ],
-          "show": false
+          "fields": "",
+          "values": false
         },
-        "frameIndex": 7,
-        "showHeader": false
+        "showUnfilled": true
       },
       "pluginVersion": "9.4.7",
       "targets": [
@@ -145,173 +141,118 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "topk(10, count by (__name__)({__name__=~\"^[a-b].+\"}))",
-          "format": "table",
+          "expr": "topk(20, metrics_cardinality:topk20{})",
+          "format": "time_series",
+          "hide": false,
           "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
+          "legendFormat": "{{name_label}}",
+          "range": true,
           "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_AWS-OBSERVABILITY-ACCELERATOR}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "topk(10, count by (__name__)({__name__=~\"^[c-d].+\"}))",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_AWS-OBSERVABILITY-ACCELERATOR}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "topk(10, count by (__name__)({__name__=~\"^[e-f].+\"}))",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_AWS-OBSERVABILITY-ACCELERATOR}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "topk(10, count by (__name__)({__name__=~\"^[g-i].+\"}))",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "D"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_AWS-OBSERVABILITY-ACCELERATOR}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "topk(10, count by (__name__)({__name__=~\"^[j-l].+\"}))",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "E"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_AWS-OBSERVABILITY-ACCELERATOR}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "topk(10, count by (__name__)({__name__=~\"^[m-o].+\"}))",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "F"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_AWS-OBSERVABILITY-ACCELERATOR}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "topk(10, count by (__name__)({__name__=~\"^[p-r].+\"}))",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "G"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_AWS-OBSERVABILITY-ACCELERATOR}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "topk(10, count by (__name__)({__name__=~\"^[s-z].+\"}))",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "H"
         }
       ],
       "title": "Top 20 high cardinality metrics",
-      "transformations": [
-        {
-          "id": "merge",
-          "options": {}
-        },
-        {
-          "id": "calculateField",
-          "options": {
-            "mode": "reduceRow",
-            "reduce": {
-              "include": [],
-              "reducer": "sum"
+      "transformations": [],
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_AWS-OBSERVABILITY-ACCELERATOR}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
             },
-            "replaceFields": false
-          }
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Value #A": true,
-              "Value #B": true,
-              "Value #C": true,
-              "Value #D": true,
-              "Value #E": true,
-              "Value #F": true,
-              "Value #G": true,
-              "Value #H": true
+            "lineInterpolation": "smooth",
+            "lineStyle": {
+              "fill": "solid"
             },
-            "indexByName": {},
-            "renameByName": {}
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
               {
-                "desc": true,
-                "field": "Total"
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
               }
             ]
           }
         },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 13,
+        "x": 11,
+        "y": 0
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.4.7",
+      "targets": [
         {
-          "id": "limit",
-          "options": {
-            "limitField": 20
-          }
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_AWS-OBSERVABILITY-ACCELERATOR}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "topk(20, metrics_cardinality:topk20{})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{name_label}}",
+          "range": true,
+          "refId": "A"
         }
       ],
-      "type": "table"
+      "title": "Top 20 high cardinality metrics",
+      "transformations": [],
+      "type": "timeseries"
     },
     {
       "datasource": {
@@ -374,7 +315,7 @@
         "h": 7,
         "w": 13,
         "x": 11,
-        "y": 0
+        "y": 11
       },
       "id": 26,
       "options": {
@@ -404,134 +345,6 @@
       ],
       "title": "Scrape series per job",
       "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_AWS-OBSERVABILITY-ACCELERATOR}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 6,
-        "x": 11,
-        "y": 7
-      },
-      "id": 25,
-      "options": {
-        "displayMode": "basic",
-        "minVizHeight": 10,
-        "minVizWidth": 0,
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showUnfilled": true
-      },
-      "pluginVersion": "9.4.7",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_AWS-OBSERVABILITY-ACCELERATOR}"
-          },
-          "editorMode": "code",
-          "expr": "sum by (job) (up) ",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Jobs",
-      "type": "bargauge"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_AWS-OBSERVABILITY-ACCELERATOR}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "continuous-GrYlRd"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 7,
-        "x": 17,
-        "y": 7
-      },
-      "id": 28,
-      "options": {
-        "displayMode": "basic",
-        "minVizHeight": 10,
-        "minVizWidth": 0,
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showUnfilled": true
-      },
-      "pluginVersion": "9.4.7",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_AWS-OBSERVABILITY-ACCELERATOR}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum by (alertname) (ALERTS{})",
-          "instant": true,
-          "legendFormat": "{{alertname}}",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "alerts firing",
-      "type": "bargauge"
     },
     {
       "datasource": {
@@ -594,7 +407,7 @@
         "h": 7,
         "w": 9,
         "x": 0,
-        "y": 15
+        "y": 18
       },
       "id": 6,
       "options": {
@@ -697,7 +510,7 @@
         "h": 7,
         "w": 15,
         "x": 9,
-        "y": 15
+        "y": 18
       },
       "id": 2,
       "options": {
@@ -753,8 +566,7 @@
             "mode": "percentage",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           }
@@ -763,9 +575,9 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 9,
+        "w": 7,
         "x": 0,
-        "y": 22
+        "y": 25
       },
       "id": 30,
       "options": {
@@ -817,6 +629,72 @@
         "type": "prometheus",
         "uid": "${DS_AWS-OBSERVABILITY-ACCELERATOR}"
       },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-GrYlRd"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 7,
+        "y": 25
+      },
+      "id": 28,
+      "options": {
+        "displayMode": "basic",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "9.4.7",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_AWS-OBSERVABILITY-ACCELERATOR}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (alertname) (ALERTS{})",
+          "instant": true,
+          "legendFormat": "{{alertname}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "alerts firing",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_AWS-OBSERVABILITY-ACCELERATOR}"
+      },
       "description": "Helps finding out variance in samples collected between scrape intervals",
       "fieldConfig": {
         "defaults": {
@@ -835,8 +713,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -849,9 +726,9 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 15,
-        "x": 9,
-        "y": 22
+        "w": 9,
+        "x": 15,
+        "y": 25
       },
       "id": 27,
       "options": {
@@ -988,13 +865,13 @@
     ]
   },
   "time": {
-    "from": "now-3h",
+    "from": "now-6h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "AWS Observability Accelerator - AMP Ingestion Dashboard",
   "uid": "qbYzyPXVz",
-  "version": 34,
+  "version": 39,
   "weekStart": ""
 }

--- a/artifacts/grafana-dashboards/amp/ingest_insights.yaml
+++ b/artifacts/grafana-dashboards/amp/ingest_insights.yaml
@@ -1,0 +1,37 @@
+groups:
+- name: ingest-insights
+  interval: 10m
+  rules:
+  - record: metrics_cardinality:topk20
+    expr: |
+      topk(20,
+          (
+              label_replace(topk(20, count by (__name__) ({__name__=~"^a.+"})), "name_label","$1","__name__", "(.+)") or on(__name__)
+              label_replace(topk(20, count by (__name__) ({__name__=~"^b.+"})), "name_label","$1","__name__", "(.+)") or on(__name__)
+              label_replace(topk(20, count by (__name__) ({__name__=~"^c.+"})), "name_label","$1","__name__", "(.+)") or on(__name__)
+              label_replace(topk(20, count by (__name__) ({__name__=~"^d.+"})), "name_label","$1","__name__", "(.+)") or on(__name__)
+              label_replace(topk(20, count by (__name__) ({__name__=~"^e.+"})), "name_label","$1","__name__", "(.+)") or on(__name__)
+              label_replace(topk(20, count by (__name__) ({__name__=~"^f.+"})), "name_label","$1","__name__", "(.+)") or on(__name__)
+              label_replace(topk(20, count by (__name__) ({__name__=~"^g.+"})), "name_label","$1","__name__", "(.+)") or on(__name__)
+              label_replace(topk(20, count by (__name__) ({__name__=~"^h.+"})), "name_label","$1","__name__", "(.+)") or on(__name__)
+              label_replace(topk(20, count by (__name__) ({__name__=~"^i.+"})), "name_label","$1","__name__", "(.+)") or on(__name__)
+              label_replace(topk(20, count by (__name__) ({__name__=~"^j.+"})), "name_label","$1","__name__", "(.+)") or on(__name__)
+              label_replace(topk(20, count by (__name__) ({__name__=~"^k.+"})), "name_label","$1","__name__", "(.+)") or on(__name__)
+              label_replace(topk(20, count by (__name__) ({__name__=~"^l.+"})), "name_label","$1","__name__", "(.+)") or on(__name__)
+              label_replace(topk(20, count by (__name__) ({__name__=~"^m.+"})), "name_label","$1","__name__", "(.+)") or on(__name__)
+              label_replace(topk(20, count by (__name__) ({__name__=~"^n.+"})), "name_label","$1","__name__", "(.+)") or on(__name__)
+              label_replace(topk(20, count by (__name__) ({__name__=~"^o.+"})), "name_label","$1","__name__", "(.+)") or on(__name__)
+              label_replace(topk(20, count by (__name__) ({__name__=~"^p.+"})), "name_label","$1","__name__", "(.+)") or on(__name__)
+              label_replace(topk(20, count by (__name__) ({__name__=~"^q.+"})), "name_label","$1","__name__", "(.+)") or on(__name__)
+              label_replace(topk(20, count by (__name__) ({__name__=~"^r.+"})), "name_label","$1","__name__", "(.+)") or on(__name__)
+              label_replace(topk(20, count by (__name__) ({__name__=~"^s.+"})), "name_label","$1","__name__", "(.+)") or on(__name__)
+              label_replace(topk(20, count by (__name__) ({__name__=~"^t.+"})), "name_label","$1","__name__", "(.+)") or on(__name__)
+              label_replace(topk(20, count by (__name__) ({__name__=~"^u.+"})), "name_label","$1","__name__", "(.+)") or on(__name__)
+              label_replace(topk(20, count by (__name__) ({__name__=~"^v.+"})), "name_label","$1","__name__", "(.+)") or on(__name__)
+              label_replace(topk(20, count by (__name__) ({__name__=~"^w.+"})), "name_label","$1","__name__", "(.+)") or on(__name__)
+              label_replace(topk(20, count by (__name__) ({__name__=~"^x.+"})), "name_label","$1","__name__", "(.+)") or on(__name__)
+              label_replace(topk(20, count by (__name__) ({__name__=~"^y.+"})), "name_label","$1","__name__", "(.+)") or on(__name__)
+              label_replace(topk(20, count by (__name__) ({__name__=~"^z.+"})), "name_label","$1","__name__", "(.+)")
+          )
+      )
+


### PR DESCRIPTION
This updates the current AMP dashboard to use promql queries with the workspace data and a mix of CW metrics.
