### PR TITLE
added infrastructure resources to java kustomization.yaml

### DIFF
--- a/artifacts/grafana-operator-manifests/eks/java/kustomization.yaml
+++ b/artifacts/grafana-operator-manifests/eks/java/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ../infrastructure
   - amg_grafana-dashboards.yaml


### PR DESCRIPTION
This is to avoid multiple Kustomization manifests in Flux. At the moment, Flux add-on in EKS Blueprints CDK does not support multiple Kustomizations.
I though believe that it is a better approach if whenever possible a single path is provided to Flux and the kustomization.yaml file in there takes care of referencing all files and paths needed.

