### PR TITLE
sample yaml file for NGINX Mon Pattern Traffic Routing and NGINX resource issue

### DIFF
--- a/artifacts/k8s-deployment-manifest-templates/nginx/nginx-traffic-sample.yaml
+++ b/artifacts/k8s-deployment-manifest-templates/nginx/nginx-traffic-sample.yaml
@@ -92,14 +92,14 @@ spec:
         backend:
           service:
             name: apple-service
-            port: 
+            port:
               number: 5678
       - path: /banana
         pathType: Prefix
         backend:
           service:
             name: banana-service
-            port: 
+            port:
               number: 5678
   ingressClassName: nginx
 

--- a/artifacts/k8s-deployment-manifest-templates/nginx/nginx-traffic-sample.yaml
+++ b/artifacts/k8s-deployment-manifest-templates/nginx/nginx-traffic-sample.yaml
@@ -1,0 +1,125 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{namespace}}
+  labels:
+    name: {{namespace}}
+
+---
+
+kind: Pod
+apiVersion: v1
+metadata:
+  name: banana-app
+  namespace: {{namespace}}
+  labels:
+    app: banana
+spec:
+  containers:
+    - name: banana-app
+      image: hashicorp/http-echo
+      args:
+        - "-text=banana"
+      resources:
+        limits:
+          cpu:  100m
+          memory: 100Mi
+        requests:
+          cpu: 50m
+          memory: 50Mi
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: banana-service
+  namespace: {{namespace}}
+spec:
+  selector:
+    app: banana
+  ports:
+    - port: 5678 # Default port for image
+
+---
+
+kind: Pod
+apiVersion: v1
+metadata:
+  name: apple-app
+  namespace: {{namespace}}
+  labels:
+    app: apple
+spec:
+  containers:
+    - name: apple-app
+      image: hashicorp/http-echo
+      args:
+        - "-text=apple"
+      resources:
+        limits:
+          cpu:  100m
+          memory: 100Mi
+        requests:
+          cpu: 50m
+          memory: 50Mi
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: apple-service
+  namespace: {{namespace}}
+spec:
+  selector:
+    app: apple
+  ports:
+    - port: 5678 # Default port for image
+
+---
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-nginx-demo
+  namespace: {{namespace}}
+spec:
+  rules:
+  - host: {{external_ip}}
+    http:
+      paths:
+      - path: /apple
+        pathType: Prefix
+        backend:
+          service:
+            name: apple-service
+            port: 
+              number: 5678
+      - path: /banana
+        pathType: Prefix
+        backend:
+          service:
+            name: banana-service
+            port: 
+              number: 5678
+  ingressClassName: nginx
+
+---
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: traffic-generator
+  namespace: {{namespace}}
+spec:
+  containers:
+    - name: traffic-generator
+      image: ellerbrock/alpine-bash-curl-ssl
+      command: ["/bin/bash"]
+      args: ["-c", "while :; do curl http://{{external_ip}}/apple > /dev/null 2>&1; curl http://{{external_ip}}/banana > /dev/null 2>&1; sleep 0.05; done"]
+      resources:
+        limits:
+          cpu:  100m
+          memory: 100Mi
+        requests:
+          cpu: 50m
+          memory: 50Mi


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-observability/cdk-aws-observability-accelerator/issues/125

*Description of changes:*
Since origin yaml file is outdated, it disturbs customer's nginx observability accelerator hands-on-lab experience.
Also, PR has been up for several months, yet the changes have not been reflected.
(relevant link: https://github.com/aws-samples/amazon-cloudwatch-container-insights/pull/120)

To mitigate this, add latest yaml file to this repo for customer's smooth hands-on-lab experience. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

