### PR TITLE
fix:url mandatory for datasource since opeator version > 5.4.0

### DIFF
--- a/artifacts/grafana-operator-manifests/eks/infrastructure/amg_grafana-cw-datasource.yaml
+++ b/artifacts/grafana-operator-manifests/eks/infrastructure/amg_grafana-cw-datasource.yaml
@@ -12,6 +12,7 @@ spec:
     type: cloudwatch
     access: server
     isDefault: false
+    url: ""
     jsonData:
       'tlsSkipVerify': false
       'timeInterval': "5s"

--- a/artifacts/grafana-operator-manifests/eks/infrastructure/amg_grafana-xray-datasource.yaml
+++ b/artifacts/grafana-operator-manifests/eks/infrastructure/amg_grafana-xray-datasource.yaml
@@ -11,6 +11,7 @@ spec:
     name: aws-observability-accelerator-xray
     type: grafana-x-ray-datasource
     access: server
+    url: ""
     isDefault: false
     jsonData:
       "authType": "ec2_iam_role"


### PR DESCRIPTION
With current datasource yaml we can't upgrade grafana operator to more recent version.

*Description of changes:*
Add 'url' to datasource yaml to be compliant with grafana-operator > 5.4.0

See: https://github.com/grafana-operator/grafana-operator/pull/1235


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

